### PR TITLE
fix: :bug: `mumbleFix` incorrectly referenced in config

### DIFF
--- a/src/components/Content/Patcher.vue
+++ b/src/components/Content/Patcher.vue
@@ -322,7 +322,7 @@ export default {
       {
         name: 'Mumble fix',
         icon: 'mumble.png',
-        internal: 'mumble',
+        internal: 'mumbleFix',
         enabled: false,
       },
       {


### PR DESCRIPTION
Changed `mumble` -> `mumbleFix`, to correctly reflect the `config.json` format
from SolarPatcher.
