### PR TITLE
Make it clear to select the 'bin' folder for JRE

### DIFF
--- a/src/javascript/minecraft.js
+++ b/src/javascript/minecraft.js
@@ -98,7 +98,7 @@ export async function checkJRE() {
       type: 'error',
       title: 'JRE not found',
       message:
-        'The JRE you selected was not found or is invalid.\n\nPlease select a valid JRE in the settings page or download one using the JRE downloader.',
+        'The JRE you selected was not found or is invalid.\n\nPlease select a valid JRE in the settings page or download one using the JRE downloader.\n\nMake sure you selected the bin folder inside of the JRE.',
       buttons: ['Select JRE', 'Cancel launch'],
     });
 


### PR DESCRIPTION
Makes it more clear to select the 'bin' folder inside of a custom JRE in the 'Invalid JRE' message.
https://github.com/Solar-Tweaks/Solar-Tweaks/issues/134