### PR TITLE
Add a note about an error whilst building

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Finally if you want to build the app run this command. All executables, installe
 $ npm run build
 ```
 
+**Note:** If you have an error that is `"error:0308010C:digital envelope routines::unsupported"`, then before running any `npm run` commands, run `set NODE_OPTIONS=--openssl-legacy-provider` in Command Prompt on Windows or `export NODE_OPTIONS=--openssl-legacy-provider` on Linux. 
+
 # Contribute ⌨️
 
 There are a lot of ways to contribute to Solar Tweaks:


### PR DESCRIPTION
Adds a note on how to fix the "error:0308010C:digital envelope routines::unsupported" error on latest versions of NodeJS. I guess that this could be considered as a temporary fix as it is not actually solving the problem, but I guess this is a temporary one that works for now.

Source: https://stackoverflow.com/questions/69692842/error-message-error0308010cdigital-envelope-routinesunsupported