### PR TITLE
fix: :bug: launching with JVM environment no longer crashes

### DIFF
--- a/src/javascript/minecraft.js
+++ b/src/javascript/minecraft.js
@@ -369,7 +369,7 @@ export async function checkGameFiles(metadata) {
     );
     logger.debug(
       `Checking game file ${parseInt(index) + 1}/${
-        metadata.launchTypeData.artifacts.length
+      metadata.launchTypeData.artifacts.length
       }`
     );
 
@@ -680,6 +680,12 @@ export async function launchGame(metadata, serverIp = null, debug = false) {
     cwd: join(constants.DOTLUNARCLIENT, 'offline', 'multiver'),
     detached: true,
     shell: debug,
+    env: {
+      ...process.env,
+      "_JAVA_OPTIONS": "",
+      "JAVA_TOOL_OPTIONS": "",
+      "JDK_JAVA_OPTIONS": "",
+    }
   });
 
   proc.on('error', (error) => {


### PR DESCRIPTION
This is because the `_JAVA_OPTIONS` environment variable takes precedence over the CLI arguments, which breaks if this variable is set. This has happens to certain users, where the variable contains an out-of-bounds RAM limit, for whatever reason.

Had some users crashing in the Solar Socket Discord, no idea why the variable is set but this fixes it anyway.